### PR TITLE
Re-enable ShulkerBoxTooltip integration

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 	modImplementation("me.shedaniel.cloth:cloth-config:${rootProject.cloth_config_version}")
 	modImplementation("me.shedaniel.cloth:cloth-config-fabric:${rootProject.cloth_config_version}") { transitive = false }
 
-    modCompileOnly modRuntimeOnly("com.misterpemodder:shulkerboxtooltip-fabric:${rootProject.shulker_box_tooltip_version}")
+    modImplementation("com.misterpemodder:shulkerboxtooltip-fabric:${rootProject.shulker_box_tooltip_version}") { transitive false }
 }
 
 processResources {

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 
     modImplementation("me.shedaniel.cloth:cloth-config-forge:${rootProject.cloth_config_version}")
 
-    // modCompileOnly modRuntimeOnly("com.misterpemodder:shulkerboxtooltip-forge:${rootProject.shulker_box_tooltip_version}")
+    modImplementation("com.misterpemodder:shulkerboxtooltip-forge:${rootProject.shulker_box_tooltip_version}") { transitive false }
 }
 
 processResources {

--- a/forge/src/main/java/net/enderitemc/enderitemod/forge/EnderiteModForge.java
+++ b/forge/src/main/java/net/enderitemc/enderitemod/forge/EnderiteModForge.java
@@ -3,7 +3,7 @@ package net.enderitemc.enderitemod.forge;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-// import com.misterpemodder.shulkerboxtooltip.api.forge.ShulkerBoxTooltipPlugin;
+import com.misterpemodder.shulkerboxtooltip.api.forge.ShulkerBoxTooltipPlugin;
 
 import dev.architectury.platform.forge.EventBuses;
 import dev.architectury.registry.client.rendering.BlockEntityRendererRegistry;
@@ -16,7 +16,7 @@ import net.enderitemc.enderitemod.forge.tools.EnderiteElytraChestplate;
 import net.enderitemc.enderitemod.forge.tools.EnderiteElytraSeperated;
 import net.enderitemc.enderitemod.materials.EnderiteArmorMaterial;
 import net.enderitemc.enderitemod.misc.EnderiteElytraFeatureRender;
-// import net.enderitemc.enderitemod.modIntegrations.ShulkerBoxTooltipApiImplementation;
+import net.enderitemc.enderitemod.modIntegrations.ShulkerBoxTooltipApiImplementation;
 import net.enderitemc.enderitemod.shulker.EnderiteShulkerBoxBlockEntity;
 import net.enderitemc.enderitemod.shulker.EnderiteShulkerBoxBlockEntityRenderer;
 import net.minecraft.block.DispenserBlock;
@@ -110,11 +110,11 @@ public class EnderiteModForge {
                                                                 (mc, screen) -> new ClothConfig(screen).getScreen()));
                         }
 
-                        // if (ModList.get().isLoaded("shulkerboxtooltip")) {
-                        //         ModLoadingContext.get().registerExtensionPoint(ShulkerBoxTooltipPlugin.class,
-                        //                         () -> new ShulkerBoxTooltipPlugin(
-                        //                                         ShulkerBoxTooltipApiImplementation::new));
-                        // }
+                        if (ModList.get().isLoaded("shulkerboxtooltip")) {
+                                ModLoadingContext.get().registerExtensionPoint(ShulkerBoxTooltipPlugin.class,
+                                                () -> new ShulkerBoxTooltipPlugin(
+                                                                ShulkerBoxTooltipApiImplementation::new));
+                        }
                 }
 
                 @SubscribeEvent(priority = EventPriority.LOW)


### PR DESCRIPTION
This pull request re-enables the integration with ShulkerBoxTooltip.

The crash was caused by one of my dependency being included as transitive.
I set `transitive` to `false` in Gradle and updated the README of SBTT accordingly.