### PR TITLE
fixed dedicated server crash when ShulkerBoxTooltip was present

### DIFF
--- a/common/src/main/java/net/enderitemc/enderitemod/modIntegrations/EnderiteShulkerBoxPreviewProvider.java
+++ b/common/src/main/java/net/enderitemc/enderitemod/modIntegrations/EnderiteShulkerBoxPreviewProvider.java
@@ -18,6 +18,6 @@ public class EnderiteShulkerBoxPreviewProvider extends BlockEntityPreviewProvide
 
     @Environment(EnvType.CLIENT)
     public ColorKey getWindowColorKey(PreviewContext context) {
-        return ShulkerBoxTooltipApiImplementation.ENDERITE_COLOR_KEY;
+        return ShulkerBoxTooltipApiImplementation.ClientOnly.ENDERITE_COLOR_KEY;
     }
 }

--- a/common/src/main/java/net/enderitemc/enderitemod/modIntegrations/ShulkerBoxTooltipApiImplementation.java
+++ b/common/src/main/java/net/enderitemc/enderitemod/modIntegrations/ShulkerBoxTooltipApiImplementation.java
@@ -19,11 +19,16 @@ public class ShulkerBoxTooltipApiImplementation implements ShulkerBoxTooltipApi 
                 EnderiteMod.ENDERITE_SHULKER_BOX.get().asItem());
     }
 
-    public static final ColorKey ENDERITE_COLOR_KEY = ColorKey.ofRgb(new float[] { (float) 20 * 2.5f / 255.0F, (float) 66 * 2.5f / 255.0F, (float) 58 * 2.5f / 255.0F });
-
     @Environment(EnvType.CLIENT)
     public void registerColors(ColorRegistry registry) {
-        registry.category(new Identifier("enderitemod","enderite_category")).register(ENDERITE_COLOR_KEY, "enderite_color");
+        registry.category(new Identifier("enderitemod","enderite_category"))
+              .register(ClientOnly.ENDERITE_COLOR_KEY, "enderite_color");
+    }
+
+    @Environment(EnvType.CLIENT)
+    public static class ClientOnly {
+        public static final ColorKey ENDERITE_COLOR_KEY = ColorKey.ofRgb(
+                new float[] {(float) 20 * 2.5f / 255.0F, (float) 66 * 2.5f / 255.0F, (float) 58 * 2.5f / 255.0F});
     }
 
 }


### PR DESCRIPTION
This PR fixes https://github.com/MisterPeModder/ShulkerBoxTooltip/issues/141

When running Enderite an ShulkerBoxTooltip on a dedicated server, the server would crash on player join.
This was caused by the client-only `ColorKey` class being loaded.

I put the `ENDERITE_COLOR_KEY` constant into a dedicated `ClientIOnly` subclass that is annotated with `@Environment(EnvType.CLIENT)` to prevent it from crashing the server upon plugin initialization.