### PR TITLE
Fabric 1.18.2 Latest Twilight Forest Compat Patch

### DIFF
--- a/src/main/java/net/enderitemc/enderitemod/misc/EnderiteElytraSpecialRecipe.java
+++ b/src/main/java/net/enderitemc/enderitemod/misc/EnderiteElytraSpecialRecipe.java
@@ -86,7 +86,6 @@ public class EnderiteElytraSpecialRecipe extends SpecialCraftingRecipe {
         }
     }
 
-    @Environment(EnvType.CLIENT)
     public boolean fits(int width, int height) {
         return width * height >= 2;
     }

--- a/src/main/java/net/enderitemc/enderitemod/misc/EnderiteShieldDecorationRecipe.java
+++ b/src/main/java/net/enderitemc/enderitemod/misc/EnderiteShieldDecorationRecipe.java
@@ -82,7 +82,7 @@ public class EnderiteShieldDecorationRecipe extends SpecialCraftingRecipe {
         }
     }
 
-    @Environment(EnvType.CLIENT)
+    @Override
     public boolean fits(int width, int height) {
         return width * height >= 2;
     }


### PR DESCRIPTION
Fixes 2 crashes when trying to uncraft any item with the Twilight Forest Uncrafting Table, changes recommended by Twilight Forest Fabric team and tested on server and client.